### PR TITLE
Version bump to ghc 7.6.1

### DIFF
--- a/Numeric/FFT/Vector/Base.hsc
+++ b/Numeric/FFT/Vector/Base.hsc
@@ -38,6 +38,7 @@ import Foreign.C (CInt, CUInt)
 import Data.Bits ( (.&.) )
 import Data.Complex(Complex(..))
 import Foreign.Storable.Complex()
+import Foreign.C.Types (CInt(..))
 
 
 
@@ -98,7 +99,7 @@ planOutputSize = MS.length . planOutput
 --
 -- If @'planInputSize' p /= length v@, then calling
 -- @execute p v@ will throw an exception.
-execute :: (Vector v a, Vector v b, Storable a, Storable b) 
+execute :: (Vector v a, Vector v b, Storable a, Storable b)
             => Plan a b -> v a -> v b
 execute Plan{..} = \v -> -- fudge the arity to make sure it's always inlined
     if n /= V.length v
@@ -123,7 +124,7 @@ execute Plan{..} = \v -> -- fudge the arity to make sure it's always inlined
 --
 -- If @'planInputSize' p \/= length vIn@ or @'planOutputSize' p \/= length vOut@,
 -- then calling @unsafeExecuteM p vIn vOut@ will throw an exception.
-executeM :: forall m v a b . 
+executeM :: forall m v a b .
         (PrimMonad m, MVector v a, MVector v b, Storable a, Storable b)
             => Plan a b -- ^ The plan to run.
             -> v (PrimState m) a  -- ^ The input vector.

--- a/vector-fftw.cabal
+++ b/vector-fftw.cabal
@@ -1,6 +1,6 @@
 Name:                vector-fftw
 
-Version:             0.1.2
+Version:             0.1.3
 License:             BSD3
 License-file:        LICENSE
 Author:              Judah Jacobson
@@ -40,8 +40,8 @@ Library
   Other-modules:
         Numeric.FFT.Vector.Base
   
-  Build-depends: base>=4.3 && < 4.6, vector==0.9.*, primitive==0.4.*,
-                 storable-complex==0.2.*
+  Build-depends: base>=4.3 && < 5.0, vector>=0.9, primitive>=0.4,
+                 storable-complex>=0.2
   Extra-libraries: fftw3
 
   Extensions: ForeignFunctionInterface, RecordWildCards, BangPatterns, FlexibleInstances,


### PR DESCRIPTION
Thank you for the useful vector-fftw libraries. I'd like to use it together with ghc-7.6.1. and vector 0.10.*.

I needed to add an import clause, related to the following FFI issue.
http://hackage.haskell.org/trac/ghc/ticket/5610

I prefer not to have upper bounds on the library dependencies until a real incompatibility arises, rather than to deal with version bumping every now and then. But it's up to your decision.

Best,
