### PR TITLE
Thread-safe planner invocations

### DIFF
--- a/Numeric/FFT/Vector/Base.hsc
+++ b/Numeric/FFT/Vector/Base.hsc
@@ -29,7 +29,7 @@ import qualified Data.Vector.Storable.Mutable as MS
 import Data.Vector.Generic as V hiding (forM_)
 import Data.Vector.Generic.Mutable as M
 import Data.List as L
-import Control.Monad.Primitive (RealWorld,PrimMonad(..),
+import Control.Monad.Primitive (RealWorld,PrimMonad(..), PrimBase,
             unsafePrimToPrim, unsafePrimToIO)
 import Control.Monad(forM_)
 import Foreign (Storable(..), Ptr, FunPtr,
@@ -125,7 +125,7 @@ execute Plan{..} = \v -> -- fudge the arity to make sure it's always inlined
 -- If @'planInputSize' p \/= length vIn@ or @'planOutputSize' p \/= length vOut@,
 -- then calling @unsafeExecuteM p vIn vOut@ will throw an exception.
 executeM :: forall m v a b .
-        (PrimMonad m, MVector v a, MVector v b, Storable a, Storable b)
+        (PrimBase m, MVector v a, MVector v b, Storable a, Storable b)
             => Plan a b -- ^ The plan to run.
             -> v (PrimState m) a  -- ^ The input vector.
                     -> v (PrimState m) b -- ^ The output vector.

--- a/Numeric/FFT/Vector/Unnormalized.hsc
+++ b/Numeric/FFT/Vector/Unnormalized.hsc
@@ -63,7 +63,7 @@ dft1D d = Transform {
             inputSize = id,
             outputSize = id,
             creationSizeFromInput = id,
-            makePlan = \n a b -> fftw_plan_dft_1d n a b d,
+            makePlan = \n a b -> withPlanner . fftw_plan_dft_1d n a b d,
             normalization = const id
             }
 
@@ -86,7 +86,7 @@ dftR2C = Transform {
             inputSize = id,
             outputSize = \n -> n `div` 2 + 1,
             creationSizeFromInput = id,
-            makePlan = fftw_plan_dft_r2c_1d,
+            makePlan = \n a b -> withPlanner . fftw_plan_dft_r2c_1d n a b,
             normalization = const id
         }
 
@@ -103,7 +103,7 @@ dftC2R = Transform {
             inputSize = \n -> n `div` 2 + 1,
             outputSize = id,
             creationSizeFromInput = \n -> 2 * (n-1),
-            makePlan = fftw_plan_dft_c2r_1d,
+            makePlan = \n a b -> withPlanner . fftw_plan_dft_c2r_1d n a b,
             normalization = const id
         }
 
@@ -112,7 +112,7 @@ r2rTransform kind = Transform {
                     inputSize = id,
                     outputSize = id,
                     creationSizeFromInput = id,
-                    makePlan = \n a b -> fftw_plan_r2r_1d n a b kind,
+                    makePlan = \n a b -> withPlanner . fftw_plan_r2r_1d n a b kind,
                     normalization = const id
                 }
 

--- a/TODO
+++ b/TODO
@@ -1,5 +1,3 @@
- - Thread safety of plan creation and execution (TODO: what guarantees do we
-   have from FFTW?).
  - Better docs for why plans are useful.
  - Mention that dct2 is "the" DCT.
  - Figure out why TimeFFTW.hs and time-fftw.c don't match up in timings.

--- a/vector-fftw.cabal
+++ b/vector-fftw.cabal
@@ -40,7 +40,7 @@ Library
   Other-modules:
         Numeric.FFT.Vector.Base
   
-  Build-depends: base>=4.3 && < 4.8,
+  Build-depends: base>=4.3 && < 4.9,
                  vector>=0.9 && < 0.11,
                  primitive>=0.4 && < 0.6,
                  storable-complex==0.2.*

--- a/vector-fftw.cabal
+++ b/vector-fftw.cabal
@@ -42,7 +42,7 @@ Library
   
   Build-depends: base>=4.3 && < 4.9,
                  vector>=0.9 && < 0.11,
-                 primitive>=0.4 && < 0.6,
+                 primitive>=0.6 && < 0.7,
                  storable-complex==0.2.*
   Extra-libraries: fftw3
 

--- a/vector-fftw.cabal
+++ b/vector-fftw.cabal
@@ -22,8 +22,6 @@ Description:         This package provides bindings to the fftw library for one-
                      .
                       - "Numeric.FFT.Vector.Unitary" additionally scales all transforms to preserve the L2 (sum-of-squares) norm of the
                         input.
-                     .
-                     Note that this package is currently not thread-safe.
 
 source-repository head
     type:   git


### PR DESCRIPTION
The FFTW documentation [claims](http://www.fftw.org/fftw3_doc/Thread-safety.html#Thread-safety) that `fftw_execute` is the only thread-safe function exported by the library. `vector-fftw` uses,

 * `fftw_execute`: Thread safe
 * `fftw_destroy_plan`: Called by the garbage collector as a finalizer; I'm still trying to verify that this won't be done concurrently
 * `fftw_malloc`: Examination of the [source](https://github.com/FFTW/fftw3/blob/master/kernel/kalloc.c) shows that it should be thread-safe
 * `fftw_free`: Same
 * `fftw_plan_dft_1d`: Needs mutex
 * `fftw_plan_dft_r2c_1d`: Needs mutex
 * `fftw_plan_dft_c2r_1d`: Needs mutex
 * `fftw_plan_r2r_1d`: Needs mutex

Here we add a simple `MVar`-based mutex around the planner calls, allowing the library to be used within multithreaded programs.