### PR TITLE
fix collision with forM_

### DIFF
--- a/Numeric/FFT/Vector/Base.hsc
+++ b/Numeric/FFT/Vector/Base.hsc
@@ -33,7 +33,7 @@ module Numeric.FFT.Vector.Base(
 import qualified Data.Vector.Storable as VS
 import qualified Data.Vector.Storable.Mutable as MS
 import Data.Vector.Generic as V hiding (forM_)
-import Data.Vector.Generic.Mutable as M hiding (unsafeModify)
+import Data.Vector.Generic.Mutable as M hiding (forM_, unsafeModify)
 import Data.List as L
 import Control.Concurrent.MVar
 import Control.Monad.Primitive (RealWorld,PrimMonad(..), PrimBase,


### PR DESCRIPTION
Data.Vector.Generic.Mutable also has a forM_ function in newer versions.
This collides with Control.Monad.forM_.

To make the build work again, we hide it.